### PR TITLE
Update for imgui 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "imgui-skia-renderer"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Matthew Blanchard <matthewblanc@msn.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-skia-safe = "0.39.0"
-imgui = "0.7.0"
+skia-safe = "0.43.0"
+imgui = "0.8.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@ impl Renderer {
 
                         arc.clip_rect(skclip_rect, skia_safe::ClipOp::default(), true);
                         let vertices = skia_safe::Vertices::new_copy(vertex_mode, &pos, &uv, &color, idx_slice);
-                        arc.draw_vertices(&vertices, skia_safe::BlendMode::Modulate, paint);
+                        arc.draw_vertices(&vertices, skia_safe::BlendMode::Modulate, Some(paint));
                     }
                 }
             }


### PR DESCRIPTION
Merger of https://github.com/MFEK/glif/pull/128 is a **blocker** on merger of this.